### PR TITLE
Fix overlapping slider names

### DIFF
--- a/scripts/integrate_utils.py
+++ b/scripts/integrate_utils.py
@@ -131,8 +131,8 @@ class IntegratedUtilsScript(scripts.Script):
                     freeu_b2 = gr.Slider(label="Backbone 2 (b2)", minimum=0, maximum=2, step=0.01, value=1.4)
                     freeu_s1 = gr.Slider(label="Skip 1 (s1)", minimum=0, maximum=4, step=0.01, value=1.2)
                     freeu_s2 = gr.Slider(label="Skip 2 (s2)", minimum=0, maximum=4, step=0.01, value=0.7)
-                    freeu_start_at = gr.Slider(label="Start At % of Steps", minimum=0.0, maximum=1.0, step=0.01, value=0.01)
-                    freeu_stop_at = gr.Slider(label="Stop At % of Steps", minimum=0.0, maximum=1.0, step=0.01, value=0.2)
+                    freeu_start_at = gr.Slider(label="Start At % of Steps", minimum=0.0, maximum=1.0, step=0.01, value=0.01, elem_id="freeu_start_at")
+                    freeu_stop_at = gr.Slider(label="Stop At % of Steps", minimum=0.0, maximum=1.0, step=0.01, value=0.2, elem_id="freeu_stop_at")
                     ui_components.extend([freeu_enabled, freeu_b1, freeu_b2, freeu_s1, freeu_s2, freeu_start_at, freeu_stop_at])
 
         return ui_components


### PR DESCRIPTION
## Summary
- ensure FreeU sliders have unique IDs to prevent conflicts with FBCache values

## Testing
- `python -m py_compile modules/*.py scripts/integrate_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f84e2f0083268f6130a7d1c266a4